### PR TITLE
parser: Detect series markers Mercurial produces

### DIFF
--- a/patchwork/parser.py
+++ b/patchwork/parser.py
@@ -309,7 +309,7 @@ def parse_series_marker(subject_prefixes):
         (x, n) if markers found, else (None, None)
     """
 
-    regex = re.compile('^([0-9]+)/([0-9]+)$')
+    regex = re.compile('^([0-9]+)(?:/| of )([0-9]+)$')
     m = _find_matching_prefix(subject_prefixes, regex)
     if m:
         return (int(m.group(1)), int(m.group(2)))


### PR DESCRIPTION
Unlike Git, Mercurial produces email subject lines of the
following format: `[PATCH M of N] ...`. `(?:/| of )` pattern
matches both `M/N` and `M of N` formats.