### PR TITLE
enable gzip compression for css, js. hide nginx version

### DIFF
--- a/lib/nginx/patchwork.conf
+++ b/lib/nginx/patchwork.conf
@@ -2,6 +2,13 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
+    server_tokens off;
+
+    gzip on;
+    gzip_types text/css application/javascript;
+    gzip_min_length 500;
+    gzip_disable msie6;
+
     location = favicon.ico { access_log off; log_not_found off; }
 
     location /static {


### PR DESCRIPTION
according to Google Pagespeed insights, css and js are not compressed by default

https://developers.google.com/speed/pagespeed/insights/?hl=ru&url=https%3A%2F%2Fpatchwork.openvpn.net&tab=desktop

so, enable compression