### PR TITLE
doc: Fix wrong example in usage overview

### DIFF
--- a/docs/usage/overview.rst
+++ b/docs/usage/overview.rst
@@ -131,7 +131,7 @@ Reviewed-by:
 
   For example::
 
-      Tested-by: Stephen Finucane <stephen@that.guru>
+      Reviewed-by: Stephen Finucane <stephen@that.guru>
 
 The available tags, along with the significance of said tags, varies from
 project to project and Patchwork instance to Patchwork instance. The `kernel


### PR DESCRIPTION
Looks like a simple copy and paste mistake.

Signed-off-by: Alexander Dahl <post@lespocky.de>