### PR TITLE
xmlrpc: Add patch_get_by_project_msgid function

### DIFF
--- a/patchwork/tests/test_xmlrpc.py
+++ b/patchwork/tests/test_xmlrpc.py
@@ -183,6 +183,12 @@ class XMLRPCPatchTest(XMLRPCTest, XMLRPCFilterModelTestMixin):
                                                     patch.hash)
         self.assertEqual(result['id'], patch.id)
 
+    def test_patch_get_by_project_msgid(self):
+        patch = self.create_single()
+        result = self.rpc.patch_get_by_project_msgid(patch.project.linkname,
+                                                     patch.msgid[1:-1])
+        self.assertEqual(result['id'], patch.id)
+
 
 class XMLRPCPersonTest(XMLRPCTest, XMLRPCModelTestMixin):
 

--- a/patchwork/tests/test_xmlrpc.py
+++ b/patchwork/tests/test_xmlrpc.py
@@ -177,6 +177,12 @@ class XMLRPCPatchTest(XMLRPCTest, XMLRPCFilterModelTestMixin):
         result = self.rpc.patch_get_by_hash(patch.hash)
         self.assertEqual(result['id'], patch.id)
 
+    def test_patch_get_by_project_hash(self):
+        patch = self.create_single()
+        result = self.rpc.patch_get_by_project_hash(patch.project.linkname,
+                                                    patch.hash)
+        self.assertEqual(result['id'], patch.id)
+
 
 class XMLRPCPersonTest(XMLRPCTest, XMLRPCModelTestMixin):
 

--- a/patchwork/views/xmlrpc.py
+++ b/patchwork/views/xmlrpc.py
@@ -638,6 +638,30 @@ def patch_get_by_project_hash(project, hash):
 
 
 @xmlrpc_method()
+def patch_get_by_project_msgid(project, msgid):
+    """Get a patch by its project and Message-ID.
+
+    Retrieve a patch matching a given project and Message-ID, if any
+    exists.
+
+    Args:
+        project (str): The project of the patch to retrieve.
+        msgid: The Message-ID if the patch to retrieve.
+
+    Returns:
+        The serialized patch matching both the project and the Message-ID,
+        if any, else an empty dict.
+    """
+    db_msgid = ('<%s>' % msgid)
+    try:
+        patch = Patch.objects.get(project__linkname=project,
+                                  msgid=db_msgid)
+        return patch_to_dict(patch)
+    except Patch.DoesNotExist:
+        return {}
+
+
+@xmlrpc_method()
 def patch_get_mbox(patch_id):
     """Get a patch by its ID in mbox format.
 


### PR DESCRIPTION
This is similar to patch_get_by_project_hash() but uses the Message-ID to
find the patch. Using the Message-ID has the advantage that patches that
have been modified can still be found.

Signed-off-by: Michael Olbrich <m.olbrich@pengutronix.de>