### PR TITLE
views/patch: Set correct encoding for patches

### DIFF
--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -154,7 +154,7 @@ def patch_mbox(request, project_id, msgid):
     patch = get_object_or_404(Patch, project_id=project.id, msgid=db_msgid)
     series_id = request.GET.get('series')
 
-    response = HttpResponse(content_type='text/plain')
+    response = HttpResponse(content_type='text/plain; charset=utf-8')
     if series_id:
         if not patch.series:
             raise Http404('Patch does not have an associated series. This is '


### PR DESCRIPTION
The patch_mbox view returns text/plain data without specifying a character
set, which means clients will assume the default of iso-8559-1 as defined
in the HTTP/1.1 standard. Since the data being returned is in fact utf-8
encoded, set the encoding accordingly in the HTTP Content-Type header.

Reported-by: Jakub Kicinski <kuba@kernel.org>
Suggested-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>
Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>