### PR TITLE
lib: fix table names

### DIFF
--- a/lib/sql/grant-all.mysql.sql
+++ b/lib/sql/grant-all.mysql.sql
@@ -23,7 +23,7 @@ GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_emailoptout TO 'www-data'@loca
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_event TO 'www-data'@localhost;
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_patch TO 'www-data'@localhost;
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_patchchangenotification TO 'www-data'@localhost;
-GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_comment TO 'www-data'@localhost;
+GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_patchcomment TO 'www-data'@localhost;
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_patchrelation TO 'www-data'@localhost;
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_patchtag TO 'www-data'@localhost;
 GRANT SELECT, UPDATE, INSERT, DELETE ON patchwork_person TO 'www-data'@localhost;
@@ -41,7 +41,7 @@ GRANT INSERT, SELECT ON patchwork_cover TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_covercomment TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_event TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_patch TO 'nobody'@localhost;
-GRANT INSERT, SELECT ON patchwork_comment TO 'nobody'@localhost;
+GRANT INSERT, SELECT ON patchwork_patchcomment TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_person TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_series TO 'nobody'@localhost;
 GRANT INSERT, SELECT ON patchwork_seriesreference TO 'nobody'@localhost;

--- a/lib/sql/grant-all.postgres.sql
+++ b/lib/sql/grant-all.postgres.sql
@@ -24,7 +24,7 @@ GRANT SELECT, UPDATE, INSERT, DELETE ON
 	patchwork_event,
 	patchwork_patch,
 	patchwork_patchchangenotification,
-	patchwork_comment,
+	patchwork_patchcomment,
 	patchwork_patchrelation,
 	patchwork_patchtag,
 	patchwork_person,
@@ -55,7 +55,6 @@ GRANT SELECT, UPDATE ON
 	patchwork_emailconfirmation_id_seq,
 	patchwork_event_id_seq,
 	patchwork_patch_id_seq,
-	patchwork_comment_id_seq,
 	patchwork_patchrelation_id_seq,
 	patchwork_patchtag_id_seq,
 	patchwork_person_id_seq,
@@ -74,7 +73,7 @@ GRANT INSERT, SELECT ON
 	patchwork_cover,
 	patchwork_covercomment,
 	patchwork_patch,
-	patchwork_comment,
+	patchwork_patchcomment,
 	patchwork_event,
 	patchwork_seriesreference
 TO "nobody";


### PR DESCRIPTION
Migration 0042 (introduced in 0686a73) renamed the `Comment` model
to `PatchComment`, and some of the table names changed in a51e7cf
were already correct.

This reverts a51e7cf and removes a nonexistent table name to resolve
the following error:
```
  $ psql -f lib/sql/grant-all.postgres.sql DATABASE_NAME
  BEGIN
  psql:lib/sql/grant-all.postgres.sql:38: ERROR:  relation
    "patchwork_comment" does not exist
```

Fixes: a51e7cfd95e2 ("lib: Correct PatchComment table")
Fixes: 7b967db4e12f ("lib: Update DB permissions to reflect model changes")
Cc: stephen@that.guru

Closes: #396

Signed-off-by: Ali Alnubani <alialnu@nvidia.com>