### PR TITLE
tox: fix failure due to whitespaces in passenv

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,5 @@ sphinx>=4.2.0
 reno>=3.4.0
 sphinx-rtd-theme~=1.0
 jinja2~=3.0
-sphinxcontrib-openapi~=0.7.0
-# See https://github.com/getpatchwork/patchwork/issues/442
-mistune<2.0.0
+# installing from source while we wait on https://github.com/pypi/support/issues/2463
+git+https://github.com/sphinx-contrib/openapi.git@c959438140e09c51f9c13c188c73238f766bf071

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ psycopg2-binary~=2.9.0
 sqlparse~=0.4.0
 python-dateutil~=2.8.0
 tblib~=1.7.0
-openapi-core~=0.16.2
+# FIXME: 0.16.4 has a bug that prevents us accepting null values
+openapi-core==0.16.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 minversion = 3.2
 envlist = pep8,docs,py{37,38,39}-django32,py{38,39,310}-django{40,41}
-skipsdist = true
-ignore_basepython_conflict = true
 
 [testenv]
-basepython = python3
+skip_install = true
 deps =
     -r{toxinidir}/requirements-test.txt
     django32: django~=3.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,19 @@ setenv =
     PYTHONDEVMODE = 1
     PYTHONWARNINGS = once
 passenv =
-    http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
-    DATABASE_TYPE DATABASE_USER DATABASE_PASSWORD DATABASE_HOST
-    DATABASE_PORT DATABASE_NAME DJANGO_TEST_PROCESSES
+    http_proxy
+    HTTP_PROXY
+    https_proxy
+    HTTPS_PROXY
+    no_proxy
+    NO_PROXY
+    DATABASE_TYPE
+    DATABASE_USER
+    DATABASE_PASSWORD
+    DATABASE_HOST
+    DATABASE_PORT
+    DATABASE_NAME
+    DJANGO_TEST_PROCESSES
 commands =
     python {toxinidir}/manage.py test --noinput --parallel -v 2 --timing -- {posargs:patchwork}
 


### PR DESCRIPTION
When installed tox >= 4, space-separated variables specified for passenv are no longer allowed.

Signed-off-by: You-Sheng Yang (vicamo) <vicamo@gmail.com>