### PR TITLE
black: address check failures against 23.1.0

### DIFF
--- a/patchwork/api/bundle.py
+++ b/patchwork/api/bundle.py
@@ -61,7 +61,6 @@ class BundlePermission(permissions.BasePermission):
 
 
 class BundleSerializer(BaseHyperlinkedModelSerializer):
-
     web_url = SerializerMethodField()
     project = ProjectSerializer(read_only=True)
     mbox = SerializerMethodField()
@@ -133,7 +132,6 @@ class BundleSerializer(BaseHyperlinkedModelSerializer):
 
 
 class BundleMixin(object):
-
     permission_classes = [PatchworkPermission & BundlePermission]
     serializer_class = BundleSerializer
 

--- a/patchwork/api/check.py
+++ b/patchwork/api/check.py
@@ -24,7 +24,6 @@ from patchwork.models import Patch
 
 
 class CheckSerializer(HyperlinkedModelSerializer):
-
     url = NestedHyperlinkedIdentityField(
         'api-check-detail',
         lookup_field_mapping={
@@ -85,7 +84,6 @@ class CheckSerializer(HyperlinkedModelSerializer):
 
 
 class CheckMixin(object):
-
     serializer_class = CheckSerializer
     filter_class = filterset_class = CheckFilterSet
 

--- a/patchwork/api/comment.py
+++ b/patchwork/api/comment.py
@@ -25,7 +25,6 @@ from patchwork.models import PatchComment
 
 
 class BaseCommentListSerializer(BaseHyperlinkedModelSerializer):
-
     web_url = SerializerMethodField()
     subject = SerializerMethodField()
     headers = SerializerMethodField()
@@ -93,7 +92,6 @@ class BaseCommentListSerializer(BaseHyperlinkedModelSerializer):
 
 
 class CoverCommentSerializer(BaseCommentListSerializer):
-
     url = NestedHyperlinkedIdentityField(
         'api-cover-comment-detail',
         lookup_field_mapping={
@@ -114,7 +112,6 @@ class CoverCommentSerializer(BaseCommentListSerializer):
 
 
 class CoverCommentMixin(object):
-
     permission_classes = (PatchworkPermission,)
     serializer_class = CoverCommentSerializer
 
@@ -135,7 +132,6 @@ class CoverCommentMixin(object):
 
 
 class PatchCommentSerializer(BaseCommentListSerializer):
-
     url = NestedHyperlinkedIdentityField(
         'api-patch-comment-detail',
         lookup_field_mapping={
@@ -156,7 +152,6 @@ class PatchCommentSerializer(BaseCommentListSerializer):
 
 
 class PatchCommentMixin(object):
-
     permission_classes = (PatchworkPermission,)
     serializer_class = PatchCommentSerializer
 

--- a/patchwork/api/cover.py
+++ b/patchwork/api/cover.py
@@ -19,7 +19,6 @@ from patchwork.models import Cover
 
 
 class CoverListSerializer(BaseHyperlinkedModelSerializer):
-
     web_url = SerializerMethodField()
     project = ProjectSerializer(read_only=True)
     submitter = PersonSerializer(read_only=True)
@@ -75,7 +74,6 @@ class CoverListSerializer(BaseHyperlinkedModelSerializer):
 
 
 class CoverDetailSerializer(CoverListSerializer):
-
     headers = SerializerMethodField()
 
     def get_headers(self, instance):

--- a/patchwork/api/embedded.py
+++ b/patchwork/api/embedded.py
@@ -79,7 +79,6 @@ class WebURLMixin(BaseHyperlinkedModelSerializer):
 
 class CheckSerializer(SerializedRelatedField):
     class _Serializer(BaseHyperlinkedModelSerializer):
-
         url = NestedHyperlinkedIdentityField(
             'api-check-detail',
             lookup_field_mapping={
@@ -135,7 +134,6 @@ class CoverSerializer(SerializedRelatedField):
 
 class CoverCommentSerializer(SerializedRelatedField):
     class _Serializer(MboxMixin, WebURLMixin, BaseHyperlinkedModelSerializer):
-
         url = NestedHyperlinkedIdentityField(
             'api-cover-comment-detail',
             lookup_field_mapping={
@@ -198,7 +196,6 @@ class PatchSerializer(SerializedRelatedField):
 
 class PatchCommentSerializer(SerializedRelatedField):
     class _Serializer(MboxMixin, WebURLMixin, BaseHyperlinkedModelSerializer):
-
         url = NestedHyperlinkedIdentityField(
             'api-patch-comment-detail',
             lookup_field_mapping={
@@ -246,7 +243,6 @@ class PersonSerializer(SerializedRelatedField):
 
 class ProjectSerializer(SerializedRelatedField):
     class _Serializer(BaseHyperlinkedModelSerializer):
-
         link_name = CharField(max_length=255, source='linkname')
         list_id = CharField(max_length=255, source='listid')
         list_email = CharField(max_length=200, source='listemail')
@@ -326,7 +322,6 @@ class UserSerializer(SerializedRelatedField):
 
 class UserProfileSerializer(SerializedRelatedField):
     class _Serializer(BaseHyperlinkedModelSerializer):
-
         username = CharField(source='user.username')
         first_name = CharField(source='user.first_name')
         last_name = CharField(source='user.last_name')

--- a/patchwork/api/event.py
+++ b/patchwork/api/event.py
@@ -24,7 +24,6 @@ from patchwork.models import Event
 
 
 class EventSerializer(ModelSerializer):
-
     project = ProjectSerializer(read_only=True)
     actor = UserSerializer()
     patch = PatchSerializer(read_only=True)

--- a/patchwork/api/filters.py
+++ b/patchwork/api/filters.py
@@ -94,32 +94,26 @@ class ModelMultipleChoiceField(BaseMultipleChoiceField):
 
 
 class BaseField(ModelMultipleChoiceField):
-
     alternate_lookup = None
 
 
 class BaseFilter(ModelMultipleChoiceFilter):
-
     field_class = BaseField
 
 
 class PersonChoiceField(ModelMultipleChoiceField):
-
     alternate_lookup = 'email__iexact'
 
 
 class PersonFilter(ModelMultipleChoiceFilter):
-
     field_class = PersonChoiceField
 
 
 class ProjectChoiceField(ModelMultipleChoiceField):
-
     alternate_lookup = 'linkname__iexact'
 
 
 class ProjectFilter(ModelMultipleChoiceFilter):
-
     field_class = ProjectChoiceField
 
 
@@ -132,17 +126,14 @@ class StateChoiceField(ModelMultipleChoiceField):
 
 
 class StateFilter(ModelMultipleChoiceFilter):
-
     field_class = StateChoiceField
 
 
 class UserChoiceField(ModelMultipleChoiceField):
-
     alternate_lookup = 'username__iexact'
 
 
 class UserFilter(ModelMultipleChoiceFilter):
-
     field_class = UserChoiceField
 
 
@@ -166,14 +157,12 @@ class BaseFilterSet(FilterSet):
 
 
 class TimestampMixin(BaseFilterSet):
-
     # TODO(stephenfin): These should filter on a 'updated_at' field instead
     before = IsoDateTimeFilter(lookup_expr='lt', field_name='date')
     since = IsoDateTimeFilter(lookup_expr='gte', field_name='date')
 
 
 class SeriesFilterSet(TimestampMixin, BaseFilterSet):
-
     submitter = PersonFilter(queryset=Person.objects.all(), distinct=False)
     project = ProjectFilter(queryset=Project.objects.all(), distinct=False)
 
@@ -187,7 +176,6 @@ def msgid_filter(queryset, name, value):
 
 
 class CoverFilterSet(TimestampMixin, BaseFilterSet):
-
     project = ProjectFilter(queryset=Project.objects.all(), distinct=False)
     # NOTE(stephenfin): We disable the select-based HTML widgets for these
     # filters as the resulting query is _huge_
@@ -205,7 +193,6 @@ class CoverFilterSet(TimestampMixin, BaseFilterSet):
 
 
 class PatchFilterSet(TimestampMixin, BaseFilterSet):
-
     project = ProjectFilter(queryset=Project.objects.all(), distinct=False)
     # NOTE(stephenfin): We disable the select-based HTML widgets for these
     # filters as the resulting query is _huge_
@@ -242,7 +229,6 @@ class PatchFilterSet(TimestampMixin, BaseFilterSet):
 
 
 class CheckFilterSet(TimestampMixin, BaseFilterSet):
-
     user = UserFilter(queryset=User.objects.all(), distinct=False)
 
     class Meta:
@@ -251,7 +237,6 @@ class CheckFilterSet(TimestampMixin, BaseFilterSet):
 
 
 class EventFilterSet(TimestampMixin, BaseFilterSet):
-
     # NOTE(stephenfin): We disable the select-based HTML widgets for these
     # filters as the resulting query is _huge_
     # TODO(stephenfin): We should really use an AJAX widget of some form here
@@ -285,7 +270,6 @@ class EventFilterSet(TimestampMixin, BaseFilterSet):
 
 
 class BundleFilterSet(BaseFilterSet):
-
     project = ProjectFilter(queryset=Project.objects.all(), distinct=False)
     owner = UserFilter(queryset=User.objects.all(), distinct=False)
 

--- a/patchwork/api/patch.py
+++ b/patchwork/api/patch.py
@@ -77,7 +77,6 @@ class PatchConflict(APIException):
 
 
 class PatchListSerializer(BaseHyperlinkedModelSerializer):
-
     web_url = SerializerMethodField()
     project = ProjectSerializer(read_only=True)
     state = StateField()
@@ -209,7 +208,6 @@ class PatchListSerializer(BaseHyperlinkedModelSerializer):
 
 
 class PatchDetailSerializer(PatchListSerializer):
-
     headers = SerializerMethodField()
     prefixes = SerializerMethodField()
 

--- a/patchwork/api/person.py
+++ b/patchwork/api/person.py
@@ -13,7 +13,6 @@ from patchwork.models import Person
 
 
 class PersonSerializer(HyperlinkedModelSerializer):
-
     user = UserSerializer(read_only=True)
 
     class Meta:
@@ -26,7 +25,6 @@ class PersonSerializer(HyperlinkedModelSerializer):
 
 
 class PersonMixin(object):
-
     permission_classes = (IsAuthenticated,)
     serializer_class = PersonSerializer
 

--- a/patchwork/api/project.py
+++ b/patchwork/api/project.py
@@ -15,7 +15,6 @@ from patchwork.models import Project
 
 
 class ProjectSerializer(BaseHyperlinkedModelSerializer):
-
     link_name = CharField(max_length=255, source='linkname', read_only=True)
     list_id = CharField(max_length=255, source='listid', read_only=True)
     list_email = CharField(max_length=200, source='listemail', read_only=True)
@@ -63,7 +62,6 @@ class ProjectSerializer(BaseHyperlinkedModelSerializer):
 
 
 class ProjectMixin(object):
-
     permission_classes = (PatchworkPermission,)
     serializer_class = ProjectSerializer
 

--- a/patchwork/api/series.py
+++ b/patchwork/api/series.py
@@ -18,7 +18,6 @@ from patchwork.models import Series
 
 
 class SeriesSerializer(BaseHyperlinkedModelSerializer):
-
     web_url = SerializerMethodField()
     project = ProjectSerializer(read_only=True)
     submitter = PersonSerializer(read_only=True)
@@ -71,7 +70,6 @@ class SeriesSerializer(BaseHyperlinkedModelSerializer):
 
 
 class SeriesMixin(object):
-
     permission_classes = (PatchworkPermission,)
     serializer_class = SeriesSerializer
 

--- a/patchwork/api/user.py
+++ b/patchwork/api/user.py
@@ -83,7 +83,6 @@ class UserDetailSerializer(UserListSerializer):
 
 
 class UserMixin(object):
-
     queryset = User.objects.all()
     permission_classes = (permissions.IsAuthenticated, IsOwnerOrReadOnly)
 

--- a/patchwork/apps.py
+++ b/patchwork/apps.py
@@ -7,7 +7,6 @@ from django.apps import AppConfig
 
 
 class PatchworkAppConfig(AppConfig):
-
     name = 'patchwork'
     verbose_name = 'Patchwork'
 

--- a/patchwork/filters.py
+++ b/patchwork/filters.py
@@ -349,7 +349,7 @@ class ArchiveFilter(Filter):
     def key(self, key):
         self.archive_state = False
         self.applied = True
-        for (k, v) in self.param_map.items():
+        for k, v in self.param_map.items():
             if key == v:
                 self.archive_state = k
         if self.archive_state is None:
@@ -559,7 +559,7 @@ class Filters:
     def querystring(self, remove=None):
         params = self.params
 
-        for (k, v) in self.values.items():
+        for k, v in self.values.items():
             if k not in params:
                 params[k] = v
 

--- a/patchwork/forms.py
+++ b/patchwork/forms.py
@@ -137,7 +137,6 @@ class PatchForm(forms.ModelForm):
 
 
 class OptionalModelChoiceField(forms.ModelChoiceField):
-
     no_change_choice = ('*', 'no change')
     to_field_name = None
 
@@ -176,7 +175,6 @@ class OptionalBooleanField(forms.TypedChoiceField):
 
 
 class MultiplePatchForm(forms.Form):
-
     action = 'update'
     archived = OptionalBooleanField(
         choices=[

--- a/patchwork/management/commands/cron.py
+++ b/patchwork/management/commands/cron.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         errors = send_notifications()
-        for (recipient, error) in errors:
+        for recipient, error in errors:
             self.stderr.write(
                 "Failed sending to %s: %s" % (recipient.email, error)
             )

--- a/patchwork/migrations/0001_initial.py
+++ b/patchwork/migrations/0001_initial.py
@@ -8,7 +8,6 @@ import patchwork.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/patchwork/migrations/0001_squashed_0040_add_related_patches.py
+++ b/patchwork/migrations/0001_squashed_0040_add_related_patches.py
@@ -10,7 +10,6 @@ import patchwork.models
 
 
 class Migration(migrations.Migration):
-
     replaces = [
         ('patchwork', '0001_initial'),
         ('patchwork', '0002_fix_patch_state_default_values'),

--- a/patchwork/migrations/0002_fix_patch_state_default_values.py
+++ b/patchwork/migrations/0002_fix_patch_state_default_values.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0001_initial'),
     ]

--- a/patchwork/migrations/0003_add_check_model.py
+++ b/patchwork/migrations/0003_add_check_model.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('patchwork', '0002_fix_patch_state_default_values'),

--- a/patchwork/migrations/0004_add_delegation_rule_model.py
+++ b/patchwork/migrations/0004_add_delegation_rule_model.py
@@ -4,7 +4,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('patchwork', '0003_add_check_model'),

--- a/patchwork/migrations/0005_unselectable_maintainer_projects.py
+++ b/patchwork/migrations/0005_unselectable_maintainer_projects.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0004_add_delegation_rule_model'),
     ]

--- a/patchwork/migrations/0006_add_patch_diff.py
+++ b/patchwork/migrations/0006_add_patch_diff.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0005_unselectable_maintainer_projects'),
     ]

--- a/patchwork/migrations/0007_move_comment_content_to_patch_content.py
+++ b/patchwork/migrations/0007_move_comment_content_to_patch_content.py
@@ -95,7 +95,6 @@ def recreate_comments(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0006_add_patch_diff'),
     ]

--- a/patchwork/migrations/0008_add_email_mixin.py
+++ b/patchwork/migrations/0008_add_email_mixin.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0007_move_comment_content_to_patch_content'),
     ]

--- a/patchwork/migrations/0009_add_submission_model.py
+++ b/patchwork/migrations/0009_add_submission_model.py
@@ -6,7 +6,6 @@ import patchwork.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0008_add_email_mixin'),
     ]

--- a/patchwork/migrations/0010_migrate_data_from_submission_to_patch.py
+++ b/patchwork/migrations/0010_migrate_data_from_submission_to_patch.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0009_add_submission_model'),
     ]

--- a/patchwork/migrations/0011_remove_temp_fields.py
+++ b/patchwork/migrations/0011_remove_temp_fields.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0010_migrate_data_from_submission_to_patch'),
     ]

--- a/patchwork/migrations/0012_add_coverletter_model.py
+++ b/patchwork/migrations/0012_add_coverletter_model.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0011_remove_temp_fields'),
     ]

--- a/patchwork/migrations/0013_slug_check_context.py
+++ b/patchwork/migrations/0013_slug_check_context.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0012_add_coverletter_model'),
     ]

--- a/patchwork/migrations/0014_remove_userprofile_primary_project.py
+++ b/patchwork/migrations/0014_remove_userprofile_primary_project.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0013_slug_check_context'),
     ]

--- a/patchwork/migrations/0015_add_series_models.py
+++ b/patchwork/migrations/0015_add_series_models.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0014_remove_userprofile_primary_project'),
     ]

--- a/patchwork/migrations/0016_series_project.py
+++ b/patchwork/migrations/0016_series_project.py
@@ -28,7 +28,6 @@ def reverse(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     # This is necessary due to a mistake made when writing the migration.
     # PostgreSQL does not allow mixing of schema and data migrations within the
     # same transaction. Disabling transactions ensures this doesn't happen.

--- a/patchwork/migrations/0017_improved_delegation_rule_docs.py
+++ b/patchwork/migrations/0017_improved_delegation_rule_docs.py
@@ -4,7 +4,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0016_series_project'),
     ]

--- a/patchwork/migrations/0018_add_event_model.py
+++ b/patchwork/migrations/0018_add_event_model.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('patchwork', '0017_improved_delegation_rule_docs'),

--- a/patchwork/migrations/0019_userprofile_show_ids.py
+++ b/patchwork/migrations/0019_userprofile_show_ids.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0018_add_event_model'),
     ]

--- a/patchwork/migrations/0020_tag_show_column.py
+++ b/patchwork/migrations/0020_tag_show_column.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0019_userprofile_show_ids'),
     ]

--- a/patchwork/migrations/0021_django_1_10_fixes.py
+++ b/patchwork/migrations/0021_django_1_10_fixes.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0020_tag_show_column'),
     ]

--- a/patchwork/migrations/0022_add_subject_match_to_project.py
+++ b/patchwork/migrations/0022_add_subject_match_to_project.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0021_django_1_10_fixes'),
     ]

--- a/patchwork/migrations/0023_timezone_unify.py
+++ b/patchwork/migrations/0023_timezone_unify.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0022_add_subject_match_to_project'),
     ]

--- a/patchwork/migrations/0025_add_regex_validators.py
+++ b/patchwork/migrations/0025_add_regex_validators.py
@@ -4,7 +4,6 @@ import patchwork.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0024_patch_patch_project'),
     ]

--- a/patchwork/migrations/0026_add_user_bundles_backref.py
+++ b/patchwork/migrations/0026_add_user_bundles_backref.py
@@ -4,7 +4,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0025_add_regex_validators'),
     ]

--- a/patchwork/migrations/0027_remove_series_ordering.py
+++ b/patchwork/migrations/0027_remove_series_ordering.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0026_add_user_bundles_backref'),
     ]

--- a/patchwork/migrations/0028_add_comment_date_index.py
+++ b/patchwork/migrations/0028_add_comment_date_index.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0027_remove_series_ordering'),
     ]

--- a/patchwork/migrations/0029_add_list_covering_index.py
+++ b/patchwork/migrations/0029_add_list_covering_index.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0028_add_comment_date_index'),
     ]

--- a/patchwork/migrations/0030_add_submission_covering_index.py
+++ b/patchwork/migrations/0030_add_submission_covering_index.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0029_add_list_covering_index'),
     ]

--- a/patchwork/migrations/0031_add_patch_series_fields.py
+++ b/patchwork/migrations/0031_add_patch_series_fields.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0030_add_submission_covering_index'),
     ]

--- a/patchwork/migrations/0032_migrate_data_from_series_patch_to_patch.py
+++ b/patchwork/migrations/0032_migrate_data_from_series_patch_to_patch.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0031_add_patch_series_fields'),
     ]

--- a/patchwork/migrations/0033_remove_patch_series_model.py
+++ b/patchwork/migrations/0033_remove_patch_series_model.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0032_migrate_data_from_series_patch_to_patch'),
     ]

--- a/patchwork/migrations/0034_project_list_archive_url.py
+++ b/patchwork/migrations/0034_project_list_archive_url.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0033_remove_patch_series_model'),
     ]

--- a/patchwork/migrations/0035_project_list_archive_url_format.py
+++ b/patchwork/migrations/0035_project_list_archive_url_format.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0034_project_list_archive_url'),
     ]

--- a/patchwork/migrations/0036_project_commit_url_format.py
+++ b/patchwork/migrations/0036_project_commit_url_format.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0035_project_list_archive_url_format'),
     ]

--- a/patchwork/migrations/0037_event_actor.py
+++ b/patchwork/migrations/0037_event_actor.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('patchwork', '0036_project_commit_url_format'),

--- a/patchwork/migrations/0038_state_slug.py
+++ b/patchwork/migrations/0038_state_slug.py
@@ -25,7 +25,6 @@ def validate_uniqueness(apps, schema_editor):
 
 
 def populate_slug_field(apps, schema_editor):
-
     State = apps.get_model('patchwork', 'State')
 
     with transaction.atomic():
@@ -35,7 +34,6 @@ def populate_slug_field(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0037_event_actor'),
     ]

--- a/patchwork/migrations/0039_unique_series_references.py
+++ b/patchwork/migrations/0039_unique_series_references.py
@@ -70,7 +70,6 @@ def delete_duplicate_series(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [('patchwork', '0038_state_slug')]
 
     operations = [

--- a/patchwork/migrations/0040_add_related_patches.py
+++ b/patchwork/migrations/0040_add_related_patches.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0039_unique_series_references'),
     ]

--- a/patchwork/migrations/0041_python3.py
+++ b/patchwork/migrations/0041_python3.py
@@ -16,7 +16,6 @@ import patchwork.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('patchwork', '0040_add_related_patches'),

--- a/patchwork/migrations/0042_add_cover_model.py
+++ b/patchwork/migrations/0042_add_cover_model.py
@@ -32,7 +32,6 @@ def delete_coverletter_comments(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0041_python3'),
     ]

--- a/patchwork/migrations/0043_merge_patch_submission.py
+++ b/patchwork/migrations/0043_merge_patch_submission.py
@@ -74,7 +74,6 @@ def migrate_data(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     atomic = False
 
     dependencies = [

--- a/patchwork/migrations/0044_add_project_linkname_validation.py
+++ b/patchwork/migrations/0044_add_project_linkname_validation.py
@@ -6,7 +6,6 @@ import re
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0043_merge_patch_submission'),
     ]

--- a/patchwork/migrations/0045_addressed_fields.py
+++ b/patchwork/migrations/0045_addressed_fields.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0044_add_project_linkname_validation'),
     ]

--- a/patchwork/migrations/0046_patch_comment_events.py
+++ b/patchwork/migrations/0046_patch_comment_events.py
@@ -3,7 +3,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('patchwork', '0045_addressed_fields'),
     ]

--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -477,7 +477,6 @@ class Cover(SubmissionMixin):
 
 
 class Patch(SubmissionMixin):
-
     diff = models.TextField(null=True, blank=True)
     commit_ref = models.CharField(max_length=255, null=True, blank=True)
     pull_url = models.CharField(max_length=255, null=True, blank=True)
@@ -722,7 +721,6 @@ class Patch(SubmissionMixin):
 
 
 class CoverComment(EmailMixin, models.Model):
-
     cover = models.ForeignKey(
         Cover,
         related_name='comments',
@@ -772,7 +770,6 @@ class CoverComment(EmailMixin, models.Model):
 
 
 class PatchComment(EmailMixin, models.Model):
-
     patch = models.ForeignKey(
         Patch,
         related_name='comments',

--- a/patchwork/notifications.py
+++ b/patchwork/notifications.py
@@ -43,7 +43,7 @@ def send_notifications():
 
     errors = []
 
-    for (recipient, notifications) in groups:
+    for recipient, notifications in groups:
         notifications = list(notifications)
 
         if recipient.id not in qs2 or qs2[recipient.id] < len(notifications):

--- a/patchwork/paginator.py
+++ b/patchwork/paginator.py
@@ -22,7 +22,6 @@ ADJACENT_PAGES = 1
 
 class Paginator(paginator.Paginator):
     def __init__(self, request, objects):
-
         items_per_page = settings.DEFAULT_ITEMS_PER_PAGE
 
         if request.user.is_authenticated:

--- a/patchwork/parser.py
+++ b/patchwork/parser.py
@@ -68,7 +68,6 @@ class DuplicateMailError(Exception):
 
 
 class DuplicateSeriesError(Exception):
-
     pass
 
 
@@ -118,7 +117,7 @@ def sanitise_header(header_contents, header_name=None):
 
         new_value = []
 
-        for (part, _) in value:
+        for part, _ in value:
             # We have random bytes that aren't properly coded.
             # If we had a coding hint, it failed to help.
 

--- a/patchwork/signals.py
+++ b/patchwork/signals.py
@@ -242,7 +242,6 @@ def create_series_created_event(sender, instance, created, raw, **kwargs):
 
 @receiver(pre_save, sender=Patch)
 def create_series_completed_event(sender, instance, raw, **kwargs):
-
     # NOTE(stephenfin): It's actually possible for this event to be fired
     # multiple times for a given series. To trigger this case, you would need
     # to send an additional patch to already exisiting series. This pattern

--- a/patchwork/templatetags/listurl.py
+++ b/patchwork/templatetags/listurl.py
@@ -23,7 +23,7 @@ class ListURLNode(template.defaulttags.URLNode):
     def __init__(self, kwargs):
         super(ListURLNode, self).__init__(None, [], {}, False)
         self.params = {}
-        for (k, v) in kwargs.items():
+        for k, v in kwargs.items():
             if k in list_params:
                 self.params[k] = v
 
@@ -53,7 +53,7 @@ class ListURLNode(template.defaulttags.URLNode):
         except (TypeError, template.VariableDoesNotExist):
             pass
 
-        for (k, v) in self.params.items():
+        for k, v in self.params.items():
             params[smart_str(k, 'ascii')] = v.resolve(context)
 
         if not params:

--- a/patchwork/templatetags/person.py
+++ b/patchwork/templatetags/person.py
@@ -16,7 +16,6 @@ register = template.Library()
 
 @register.filter
 def personify(person, project):
-
     if person.name:
         linktext = escape(person.name)
     else:

--- a/patchwork/templatetags/syntax.py
+++ b/patchwork/templatetags/syntax.py
@@ -72,7 +72,7 @@ def patchsyntax(patch):
 def commentsyntax(submission):
     content = escape(submission.content)
 
-    for (r, cls) in _comment_span_res:
+    for r, cls in _comment_span_res:
         content = r.sub(lambda x: _span % (cls, x.group(0)), content)
 
     return mark_safe(content)

--- a/patchwork/tests/api/utils.py
+++ b/patchwork/tests/api/utils.py
@@ -70,7 +70,6 @@ def store_samples(filename):
             def client_wrapper(
                 orig_func, path, data=None, *orig_args, **orig_kwargs
             ):
-
                 req_filename = filename + '-req.json'
                 resp_filename = filename + '-resp.json'
 

--- a/patchwork/tests/test_parser.py
+++ b/patchwork/tests/test_parser.py
@@ -132,7 +132,6 @@ class PatchTest(TestCase):
 
 
 class InlinePatchTest(PatchTest):
-
     orig_content = 'Test for attached patch'
     orig_diff = read_patch('0001-add-line.patch')
 
@@ -148,7 +147,6 @@ class InlinePatchTest(PatchTest):
 
 
 class AttachmentPatchTest(InlinePatchTest):
-
     orig_content = 'Test for attached patch'
     content_subtype = 'x-patch'
 
@@ -164,12 +162,10 @@ class AttachmentPatchTest(InlinePatchTest):
 
 
 class AttachmentXDiffPatchTest(AttachmentPatchTest):
-
     content_subtype = 'x-diff'
 
 
 class UTF8InlinePatchTest(InlinePatchTest):
-
     orig_diff = read_patch('0002-utf-8.patch', 'utf-8')
 
     def setUp(self):
@@ -193,7 +189,6 @@ class NoCharsetInlinePatchTest(InlinePatchTest):
 
 
 class SignatureCommentTest(InlinePatchTest):
-
     orig_content = 'Test comment\nmore comment'
 
     def setUp(self):
@@ -212,7 +207,6 @@ class UpdateSigCommentTest(SignatureCommentTest):
 
 
 class ListFooterTest(InlinePatchTest):
-
     orig_content = 'Test comment\nmore comment'
 
     def setUp(self):
@@ -231,7 +225,6 @@ class ListFooterTest(InlinePatchTest):
 
 
 class DiffWordInCommentTest(InlinePatchTest):
-
     orig_content = (
         'Lines can start with words beginning in "diff"\n'
         + 'difficult\nDifferent'
@@ -884,7 +877,6 @@ class CommentParseTest(TestCase):
 
 
 class DelegateRequestTest(TestCase):
-
     patch_filename = '0001-add-line.patch'
     msgid = '<1@example.com>'
     invalid_delegate_email = "nobody"
@@ -925,7 +917,6 @@ class DelegateRequestTest(TestCase):
 
 
 class CommentActionRequiredTest(TestCase):
-
     fixtures = ['default_tags']
 
     def setUp(self):
@@ -988,7 +979,6 @@ class CommentActionRequiredTest(TestCase):
 
 
 class InitialPatchStateTest(TestCase):
-
     patch_filename = '0001-add-line.patch'
     msgid = '<1@example.com>'
     invalid_state_name = "Nonexistent Test State"
@@ -1044,7 +1034,6 @@ class InitialPatchStateTest(TestCase):
 
 
 class ParseInitialTagsTest(PatchTest):
-
     fixtures = ['default_tags']
     patch_filename = '0001-add-line.patch'
     orig_content = (

--- a/patchwork/tests/test_tags.py
+++ b/patchwork/tests/test_tags.py
@@ -14,7 +14,6 @@ from patchwork.tests.utils import create_patch_comment
 
 
 class ExtractTagsTest(TestCase):
-
     fixtures = ['default_tags']
     email = 'test@example.com'
     name_email = 'test name <' + email + '>'
@@ -72,7 +71,6 @@ class ExtractTagsTest(TestCase):
 
 
 class PatchTagsTest(TransactionTestCase):
-
     fixtures = ['default_tags']
     ACK = 1
     REVIEW = 2

--- a/patchwork/tests/test_xmlrpc.py
+++ b/patchwork/tests/test_xmlrpc.py
@@ -138,7 +138,6 @@ class XMLRPCModelTestMixin(object):
 
 
 class XMLRPCFilterModelTestMixin(XMLRPCModelTestMixin):
-
     # override these tests due to the way you pass in filters
     def test_list_max_count(self):
         objs = self.create_multiple(5)

--- a/patchwork/tests/views/test_bundles.py
+++ b/patchwork/tests/views/test_bundles.py
@@ -756,7 +756,7 @@ class BundleInitialOrderTest(BundleTestBase):
         # BundlePatches should be sorted by .order by default
         bps = BundlePatch.objects.filter(bundle=bundle)
 
-        for (bp, p) in zip(bps, expected_order):
+        for bp, p in zip(bps, expected_order):
             self.assertEqual(bp.patch.pk, p.pk)
 
         bundle.delete()

--- a/patchwork/tests/views/test_patch.py
+++ b/patchwork/tests/views/test_patch.py
@@ -38,7 +38,6 @@ class EmptyPatchListTest(TestCase):
 
 
 class PatchListOrderingTest(TestCase):
-
     patchmeta = [
         (
             'AlCMyjOsx',
@@ -382,7 +381,6 @@ class PatchViewTest(TestCase):
 
 
 class PatchUpdateTest(TestCase):
-
     properties_form_id = 'patchform-properties'
 
     def setUp(self):

--- a/patchwork/views/__init__.py
+++ b/patchwork/views/__init__.py
@@ -23,7 +23,7 @@ bundle_actions = ['create', 'add', 'remove']
 def get_patch_ids(d, prefix='patch_id'):
     ids = []
 
-    for (k, v) in d.items():
+    for k, v in d.items():
         a = k.split(':')
         if len(a) != 2:
             continue
@@ -180,7 +180,6 @@ def generic_list(
     patches=None,
     editable_order=False,
 ):
-
     if not filter_settings:
         filter_settings = []
 
@@ -266,7 +265,7 @@ def generic_list(
         if errors:
             context['errors'] = errors
 
-    for (filterclass, setting) in filter_settings:
+    for filterclass, setting in filter_settings:
         if isinstance(setting, dict):
             context['filters'].set_status(filterclass, **setting)
         elif isinstance(setting, list):

--- a/patchwork/views/notification.py
+++ b/patchwork/views/notification.py
@@ -14,7 +14,6 @@ from patchwork.views import user
 
 
 def confirm(request, key):
-
     views = {
         'userperson': user.link_confirm,
         'registration': user.register_confirm,

--- a/patchwork/views/xmlrpc.py
+++ b/patchwork/views/xmlrpc.py
@@ -25,7 +25,6 @@ from patchwork.views.utils import patch_to_mbox
 
 
 class PatchworkXMLRPCDispatcher(SimpleXMLRPCDispatcher, XMLRPCDocGenerator):
-
     server_name = 'Patchwork XML-RPC API'
     server_title = 'Patchwork XML-RPC API v1 Documentation'
 
@@ -730,7 +729,7 @@ def patch_set(user, patch_id, params):
     if not patch.is_editable(user):
         raise Exception('No permissions to edit this patch')
 
-    for (k, v) in params.items():
+    for k, v in params.items():
         if k not in ok_params:
             continue
 


### PR DESCRIPTION
See black [changelogs](https://black.readthedocs.io/en/stable/change_log.html#id8). Matched changes are:
* Enforce empty lines before classes and functions with sticky leading comments (#3302) (22.12.0)
* Remove unnecessary parentheses from tuple unpacking in for loops (#2945) (22.3.0)