### PR TITLE
support python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tox
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         db: [postgres, mysql, sqlite3]
     env:
       DATABASE_TYPE: "${{ matrix.db }}"
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Build docs (via tox)
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build docker-compose service
         run: |
           docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2
-envlist = pep8,docs,py{37,38,39}-django32,py{38,39,310}-django{40,41}
+envlist = pep8,docs,py{37,38,39}-django32,py{38,39,310,311}-django{40,41}
 
 [testenv]
 skip_install = true
@@ -95,3 +95,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311


### PR DESCRIPTION
A new build from https://github.com/getpatchwork/pyenv must be triggered to actually rebuild the images to be used in docker tests. See also https://github.com/getpatchwork/pyenv/pull/1.