### PR TITLE
lib: add missing permissions for patchwork_comment_id_seq

### DIFF
--- a/lib/sql/grant-all.postgres.sql
+++ b/lib/sql/grant-all.postgres.sql
@@ -49,6 +49,7 @@ GRANT SELECT, UPDATE ON
 	patchwork_bundle_id_seq,
 	patchwork_bundlepatch_id_seq,
 	patchwork_check_id_seq,
+	patchwork_comment_id_seq,
 	patchwork_cover_id_seq,
 	patchwork_covercomment_id_seq,
 	patchwork_delegationrule_id_seq,
@@ -91,6 +92,7 @@ GRANT SELECT ON
 	patchwork_tag
 TO "nobody";
 GRANT UPDATE, SELECT ON
+	patchwork_comment_id_seq,
 	patchwork_event_id_seq,
 	patchwork_patch_id_seq,
 	patchwork_patchtag_id_seq,


### PR DESCRIPTION
Grants UPDATE and SELECT privileges on patchwork_comment_id_seq table for web and mail users to fix the following exception when comments are parsed:
```
django.db.utils.ProgrammingError: permission denied for sequence
  patchwork_comment_id_seq
```
Fixes: 5b53f46def5f ("lib: fix table names")