### PR TITLE
lib: add missing psql permissions for 'nobody' user

### DIFF
--- a/lib/sql/grant-all.postgres.sql
+++ b/lib/sql/grant-all.postgres.sql
@@ -94,6 +94,7 @@ TO "nobody";
 GRANT UPDATE, SELECT ON
 	patchwork_comment_id_seq,
 	patchwork_cover_id_seq,
+	patchwork_covercomment_id_seq,
 	patchwork_event_id_seq,
 	patchwork_patch_id_seq,
 	patchwork_patchtag_id_seq,

--- a/lib/sql/grant-all.postgres.sql
+++ b/lib/sql/grant-all.postgres.sql
@@ -93,6 +93,7 @@ GRANT SELECT ON
 TO "nobody";
 GRANT UPDATE, SELECT ON
 	patchwork_comment_id_seq,
+	patchwork_cover_id_seq,
 	patchwork_event_id_seq,
 	patchwork_patch_id_seq,
 	patchwork_patchtag_id_seq,


### PR DESCRIPTION
Grants `UPDATE` and `SELECT` privileges on `patchwork_cover_id_seq` and 
`patchwork_covercomment_id_seq` tables for user 'nobody' to resolve `ProgrammingError`
exceptions.

Related changes:
5b53f46def5f
7b967db4e12f