### PR TITLE
doc: Add required .html suffix to links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,4 +3,4 @@ Contributing
 
 For guidelines on contributing, refer to the `contributors documentation`__.
 
-__ https://patchwork.readthedocs.io/en/latest/development/contributing/
+__ https://patchwork.readthedocs.io/en/latest/development/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ project on one of these instances.
 - patchwork.sourceware.org
 - patchwork.open-mesh.org
 
-__ https://patchwork.readthedocs.io/en/latest/development/api/
-__ https://patchwork.readthedocs.io/en/latest/usage/clients/
+__ https://patchwork.readthedocs.io/en/latest/development/api.html
+__ https://patchwork.readthedocs.io/en/latest/usage/clients.html
 
 Requirements
 ------------

--- a/docs/usage/clients.rst
+++ b/docs/usage/clients.rst
@@ -9,7 +9,7 @@ APIs.
    Got a client that you think might be useful to the broader community? Feel
    free to add it to this page by `submitting a patch`__.
 
-   __ https://patchwork.readthedocs.io/en/latest/development/contributing/
+   __ https://patchwork.readthedocs.io/en/latest/development/contributing.html
 
 
 pwclient

--- a/releasenotes/notes/initial-reno-68c116ae9c5259a3.yaml
+++ b/releasenotes/notes/initial-reno-68c116ae9c5259a3.yaml
@@ -69,7 +69,7 @@ features:
   - |
     `Docker <https://www.docker.com/what-docker#/developers>`_ support is now
     integrated for development usage. To use this, refer to the `documentation
-    <https://patchwork.readthedocs.io/en/latest/development/installation/>`__.
+    <https://patchwork.readthedocs.io/en/latest/development/installation.html>`__.
 upgrade:
   - |
     The REST API is enabled by default.


### PR DESCRIPTION
Some links to https://patchwork.readthedocs.io/ require .html suffix (these which point to .rst files). Add it to fix 404 errors.