### PR TITLE
Make message ID on submission page copyable

### DIFF
--- a/patchwork/templates/patchwork/submission.html
+++ b/patchwork/templates/patchwork/submission.html
@@ -23,11 +23,12 @@
 <table id="patch-meta" class="patch-meta" data-submission-type={{submission|verbose_name_plural|lower}} data-submission-id={{submission.id}}>
   <tr>
     <th>Message ID</th>
+    <td>
+      {{ submission.url_msgid }}
 {% if submission.list_archive_url %}
-    <td>{{ submission.url_msgid }} (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)</td>
-{% else %}
-    <td>{{ submission.url_msgid }}</td>
+      (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)
 {% endif %}
+    </td>
   </tr>
 {% if submission.state %}
   <tr>

--- a/patchwork/templates/patchwork/submission.html
+++ b/patchwork/templates/patchwork/submission.html
@@ -24,7 +24,14 @@
   <tr>
     <th>Message ID</th>
     <td>
+      {% if user.is_authenticated and user.profile.show_ids %}
+        <button type="button" class="btn btn-xs btn-copy" data-clipboard-text="{{ submission.url_msgid }}" title="Copy to Clipboard">
+          {{ submission.url_msgid }}
+        </button>
+      </td>
+      {% else %}
       {{ submission.url_msgid }}
+      {% endif %}
 {% if submission.list_archive_url %}
       (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)
 {% endif %}


### PR DESCRIPTION
When working with both patchwork and b4, it's _really_ useful to be able to get the message ID quickly.

This patch uses the existing "show IDs" toggle to switch from showing the message ID as a plain text field to showing it as a clickable button, as per the existing _Patch ID_ entries in the series view:

![Screenshot 2024-01-03 at 18 00 25](https://github.com/getpatchwork/patchwork/assets/32394/6235d024-b81f-41f8-acba-02da3a48eced)

However, whilst that's consistent inside patchwork, I'm not entirely convince that's the best UX.  I have an alternative branch which instead adds clickable icons alongside the message ID:

![Screenshot 2024-01-03 at 18 01 14](https://github.com/getpatchwork/patchwork/assets/32394/4b32de84-ad1d-4670-b8d8-9fc5015de7aa)

Maintainers choice as to what they'd prefer.