### PR TITLE
Fix docker apt install requirements

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
     sqlite3 \
     tzdata \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pip install wheel tox


### PR DESCRIPTION
Add pkg-config dependency install for docker images. this is required later on for mysql inside the container.