### PR TITLE
Make message ID on submission page copyable (version 2)

### DIFF
--- a/patchwork/templates/patchwork/submission.html
+++ b/patchwork/templates/patchwork/submission.html
@@ -28,6 +28,7 @@
 {% if submission.list_archive_url %}
       (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)
 {% endif %}
+      <span class="btn-link btn-copy glyphicon glyphicon-copy" data-clipboard-text="{{ submission.url_msgid }}" title="Copy to Clipboard"></span>
     </td>
   </tr>
 {% if submission.state %}

--- a/patchwork/templates/patchwork/submission.html
+++ b/patchwork/templates/patchwork/submission.html
@@ -23,11 +23,12 @@
 <table id="patch-meta" class="patch-meta" data-submission-type={{submission|verbose_name_plural|lower}} data-submission-id={{submission.id}}>
   <tr>
     <th>Message ID</th>
+    <td>
+      {{ submission.url_msgid }}
 {% if submission.list_archive_url %}
-    <td>{{ submission.url_msgid }} (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)</td>
-{% else %}
-    <td>{{ submission.url_msgid }}</td>
+      (<a href="{{ submission.list_archive_url }}">mailing list archive</a>)
 {% endif %}
+    </td>
   </tr>
 {% if submission.state %}
   <tr>

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
     <script src="{% static "js/js.cookie.min.js" %}"></script>
     <script>
       $(document).ready(function() {
-          new Clipboard(document.querySelectorAll('button.btn-copy'));
+          new Clipboard(document.querySelectorAll('.btn-copy'));
       });
     </script>
 {% block headers %}{% endblock %}


### PR DESCRIPTION
This directly conflicts with https://github.com/getpatchwork/patchwork/pull/572.

Add a little "copy" button to the message ID field so that the user can copy the message ID to the clipboard.  This makes working with b4 from a terminal easier because it's just one-click to get the IDs.

![Screenshot 2024-01-10 at 18 10 42](https://github.com/getpatchwork/patchwork/assets/32394/df282f88-e164-42b4-93eb-4ebe74af0413)

Also depends on and incorporates https://github.com/getpatchwork/patchwork/pull/576, for the updated glyphicon font with a 'copy' icon.