### PR TITLE
chore: fix docker compose files for macos

### DIFF
--- a/docker-compose-pg.yml
+++ b/docker-compose-pg.yml
@@ -9,6 +9,7 @@ services:
       - POSTGRES_USER=patchwork
       - POSTGRES_PASSWORD=password
   web:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./tools/docker/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # https://stackoverflow.com/a/55706057
       - SYS_NICE  # CAP_SYS_NICE
   web:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ./tools/docker/Dockerfile

--- a/docs/development/installation.rst
+++ b/docs/development/installation.rst
@@ -30,6 +30,10 @@ configure Patchwork using Docker:
         package.
   __ post-install_
 
+  .. note::
+
+      Mac users might need to enable Rosetta emulation in the docker engine.
+
 #. (Optional) Create a ``.env`` file in the root directory of the project and
    store your ``UID`` and ``GID`` attribute there.
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED 1
 ENV PROJECT_HOME /home/patchwork/patchwork
 ENV DJANGO_SETTINGS_MODULE patchwork.settings.dev
 
-RUN groupadd --gid=$GID patchwork && \
+RUN groupadd -o --gid=$GID patchwork && \
     useradd --uid=$UID --gid=$GID --create-home patchwork
 RUN rm -f /etc/localtime; ln -s /usr/share/zoneinfo/$TZ /etc/localtime
 


### PR DESCRIPTION
Allow users to build the Docker image in a MacOS environment.

