### PR TITLE
templatetags: Render links as XHTML links

### DIFF
--- a/patchwork/templatetags/syntax.py
+++ b/patchwork/templatetags/syntax.py
@@ -47,6 +47,10 @@ _comment_span_res = [
 
 _span = '<span class="%s">%s</span>'
 
+_comment_link_re = re.compile(r'(https|http|git|ftp)://[^<)\s]+', re.I)
+
+_link = '<a href="%s">%s</a>'
+
 
 @register.filter
 def patchsyntax(patch):
@@ -74,5 +78,8 @@ def commentsyntax(submission):
 
     for r, cls in _comment_span_res:
         content = r.sub(lambda x: _span % (cls, x.group(0)), content)
+    content = _comment_link_re.sub(
+        lambda x: _link % (x.group(0), x.group(0)), content
+    )
 
     return mark_safe(content)


### PR DESCRIPTION
Convert links in the commit message and comments, to be rendered as clickable XHTML links for easy navigation.

Currently only http, https, ftp and git are recognized. And only links that are not broken across lines are recognized.

I have used a very simple regex to match links: It matches anything after http:// or https:// or ftp:// or git://, till it reaches a space character or '<' character (to prevent it sometimes matching a </span> tag at the end of the link). Let me know if we would need a more exhaustive regex pattern.

Closes: #591

![Screenshot 2025-04-14 at 12-24-27 net-next v2 02_14 device property Add optional nargs_prop for get_reference_args - Patchwork](https://github.com/user-attachments/assets/b65169d2-3954-47da-8f73-124d69fc54e9)

