### PR TITLE
Prevent any user from updating public bundles

### DIFF
--- a/patchwork/views/__init__.py
+++ b/patchwork/views/__init__.py
@@ -135,9 +135,13 @@ def set_bundle(request, project, action, data, patches):
         if not data['bundle_id']:
             return ['No bundle was selected']
         bundle = get_object_or_404(Bundle, id=data['bundle_id'])
+        if request.user != bundle.owner:
+            return ["You don't have permissions to add patches to bundle"]
         add_bundle_patches(request, patches, bundle)
     elif action == 'remove':
         bundle = get_object_or_404(Bundle, id=data['removed_bundle_id'])
+        if request.user != bundle.owner:
+            return ["You don't have permissions to remove patches from bundle"]
         for patch in patches:
             try:
                 bp = BundlePatch.objects.get(bundle=bundle, patch=patch)


### PR DESCRIPTION
Currently, the web UI allows any logged in user to remove patches from public bundles. However the correct behaviour is that only the owner of the bundle should be allowed to update a bundle.

Fix that by adding checks in set_bundle() before adding or removing patches from bundles.

Closes: #599

After fixing, when I try to remove a patch from a public bundle (without being an owner user), I get the following error message and the patch is not removed.

![Screenshot 2025-04-16 at 22-05-47 Linux kernel - Patchwork](https://github.com/user-attachments/assets/3d026e0d-fb79-42e8-95dc-221ea2eb87b6)
