### PR TITLE
better handle color states at patch list

### DIFF
--- a/patchwork/templatetags/patch.py
+++ b/patchwork/templatetags/patch.py
@@ -39,14 +39,9 @@ def patch_checks(patch):
     counts = patch.check_count
 
     check_elements = []
-    use_color = True
     for state in required[::-1]:
         if counts[state]:
-            if use_color:
-                use_color = False
-                color = dict(Check.STATE_CHOICES).get(state)
-            else:
-                color = ''
+            color = dict(Check.STATE_CHOICES).get(state)
             count = str(counts[state])
         else:
             color = ''


### PR DESCRIPTION
The logic which colors a check is weird: it only add the right class for up to one column.

That's weird and makes harder for people to properly idenfify  CI checks when there are multiple CI reports at the same line.

Change it to do the expected behavior, like can be seen at https://patchwork.linuxtv.org/project/linux-media/list/.