### PR TITLE
Fix empty email destination at cronjob

### DIFF
--- a/patchwork/notifications.py
+++ b/patchwork/notifications.py
@@ -73,6 +73,20 @@ def send_notifications():
             'patchwork/mails/patch-change-notification.txt', context
         )
 
+        # Got one case where recipient.email == "<>". That causes Django to fail with:
+        #   File "/usr/lib/python3/dist-packages/django/core/mail/message.py", line 99, in sanitize_address
+        #    address_parts = nm + localpart + domain
+        #                    ~~~^~~~~~~~~~~
+        # TypeError: can only concatenate str (not "NoneType") to str
+        if (
+            not recipient.email
+            or recipient.email == '<>'
+            or recipient.email == ''
+        ):
+            errors.append((recipient, 'Invalid recipient'))
+            delete_notifications()
+            continue
+
         message = EmailMessage(
             subject=subject,
             body=content,


### PR DESCRIPTION
If recipient is not filled or is invalid, email submission cronjob crashes with:

```
Traceback (most recent call last):
  File "/usr/local/patchwork/./manage.py", line 17, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/patchwork/patchwork/management/commands/cron.py", line 19, in handle
    errors = send_notifications()
             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/patchwork/patchwork/notifications.py", line 84, in send_notifications
    message.send()
  File "/usr/lib/python3/dist-packages/django/core/mail/message.py", line 284, in send
    return self.get_connection(fail_silently).send_messages([self])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/django/core/mail/backends/smtp.py", line 109, in send_messages
    sent = self._send(message)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/django/core/mail/backends/smtp.py", line 122, in _send
    recipients = [sanitize_address(addr, encoding) for addr in email_message.recipients()]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/django/core/mail/backends/smtp.py", line 122, in <listcomp>
    recipients = [sanitize_address(addr, encoding) for addr in email_message.recipients()]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/django/core/mail/message.py", line 99, in sanitize_address
    address_parts = nm + localpart + domain
                    ~~~^~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

As there's no point trying to send a notification to an invalid e-mail, just drops it.
