### PR TITLE
Add an extra style when no checks are present

### DIFF
--- a/patchwork/templatetags/patch.py
+++ b/patchwork/templatetags/patch.py
@@ -39,12 +39,21 @@ def patch_checks(patch):
     counts = patch.check_count
 
     check_elements = []
+    all_empty = True
+    for state in required:
+        if counts[state]:
+            all_empty = False
+            break
+
     for state in required[::-1]:
         if counts[state]:
             color = dict(Check.STATE_CHOICES).get(state)
             count = str(counts[state])
         else:
-            color = ''
+            if all_empty:
+                color = 'nochecks'
+            else:
+                color = ''
             count = '-'
 
         check_elements.append(


### PR DESCRIPTION
On projects where all patches are meant to be checked, not having any checks mean that either the CI is still running or that CI didn't run for an specific patch.

At the first case, the maintainers need to be aware to wait for CI to run; at the last case, if it takes too long, they may need to manually re-run CI or double-check resuls.

Anyway, this is a sort of "error" status, so allow CSS to be able to customize it, by adding a "nochecks" state-like CSS style.